### PR TITLE
DAGPLEJ-70: Hid “Fulfill order” button

### DIFF
--- a/web/modules/custom/dagplejelager_form/src/EventSubscriber/FormEventSubscriber.php
+++ b/web/modules/custom/dagplejelager_form/src/EventSubscriber/FormEventSubscriber.php
@@ -59,6 +59,14 @@ class FormEventSubscriber implements EventSubscriberInterface {
         break;
     }
 
+    if (preg_match('/^state_machine_transition_form_commerce_order_state_(.+)$/', $event->getFormId())) {
+      // Hide "Fulfill order" button (fulfillment is performed by setting
+      // “Fulfillment date“ on the order).
+      if (isset($form['actions']['fulfill'])) {
+        $form['actions']['fulfill']['#access'] = FALSE;
+      }
+    }
+
     // Handle product forms.
     if (preg_match('/^commerce_product_(.+)_(add|edit)_form$/', $event->getFormId())) {
       // Hide product (variation) price.


### PR DESCRIPTION
https://jira.itkdev.dk/browse/DAGPLEJ-70

Hides the “Fulfill order” button from admin order view.
