### PR TITLE
DAGPLEJ-92

### DIFF
--- a/config/sync/user.mail.yml
+++ b/config/sync/user.mail.yml
@@ -68,7 +68,7 @@ register_no_approval_required:
 register_pending_approval:
   subject: 'Kontoinformation for [user:display-name] på [site:name] (afventer godkendelse af administrator)'
   body: |-
-    [bruger:vist navn],
+    [user:display-name],
 
     Tak for din tilmelding på [site:name]. Din ansøgning om en konto afventer i øjeblikket godkendelse. Når den er godkendt, modtager du en anden e-mail med oplysninger om, hvordan du logger ind, angiver din adgangskode og andre detaljer.
 

--- a/config/sync/user.settings.yml
+++ b/config/sync/user.settings.yml
@@ -12,7 +12,7 @@ notify:
   register_admin_created: true
   register_no_approval_required: true
   register_pending_approval: true
-register: visitors
+register: admin_only
 cancel_method: user_cancel_block
 password_reset_timeout: 86400
 password_strength: true


### PR DESCRIPTION
https://jira.itkdev.dk/browse/DAGPLEJ-92

Allows only administrators to create new users. The OpenID Connect module overrides this setting (cf. https://github.com/itk-dev/dagplejelager/blob/develop/config/sync/openid_connect.settings.yml#L6) and allows new users to be created when authenticating via OIDC.
